### PR TITLE
feat(landing-page): update footer text and adjust impact stats for accuracy

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -12,11 +12,11 @@ export default function Footer() {
           <span className="flex items-center gap-1">
             Made with <Heart size={14} className="text-destructive" /> by{" "}
             <Link href="/" className="font-medium hover:text-primary">
-              MermaidGenie
+              MermaidGenie.
             </Link>
           </span>
           <span>
-            · Created by{" "}
+            Created by{" "}
             <Link
               href="https://sonnguyenhoang.com"
               target="_blank"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -173,17 +173,17 @@ const primaryStats = [
 const impactStats = [
   {
     label: "Mermaid nodes rendered",
-    target: 68_000_000,
+    target: 680_000,
     suffix: "+",
   },
   {
     label: "Relationships mapped",
-    target: 240_000_000,
+    target: 240_000,
     suffix: "+",
   },
   {
     label: "Docs stitched to diagrams",
-    target: 1_400_000,
+    target: 400_000,
     suffix: "+",
   },
   {
@@ -193,7 +193,7 @@ const impactStats = [
   },
   {
     label: "Diagram versions stored",
-    target: 3_400_000,
+    target: 430_000,
     suffix: "+",
   },
   {


### PR DESCRIPTION
This pull request makes minor updates to the homepage statistics and footer wording to improve accuracy and clarity. The most important changes are grouped below:

Homepage statistics updates:

* Reduced the numbers shown in the `impactStats` array in `frontend/pages/index.tsx` to reflect more accurate metrics for rendered nodes, relationships mapped, docs stitched to diagrams, and diagram versions stored. [[1]](diffhunk://#diff-286c287cf425c0eafcf41c57c6bccb2ac13ece5bfe5dc5f88d627f703ad7100eL176-R186) [[2]](diffhunk://#diff-286c287cf425c0eafcf41c57c6bccb2ac13ece5bfe5dc5f88d627f703ad7100eL196-R196)

Footer wording update:

* Added a period after "MermaidGenie" and removed the separator before "Created by" for improved readability in the `Footer` component (`frontend/components/Footer.tsx`).